### PR TITLE
Better handling of errors from the server

### DIFF
--- a/web/config.php
+++ b/web/config.php
@@ -80,6 +80,25 @@
 	$rrdoptions['instantPower']['end'] = array();
 
 	/**
+	 * Return detailed rrdtool errors to the submitting client?
+	 *
+	 * Defaults to false (disabled) and will return generic error to the client if
+	 * rrdtool errors for some reason.
+	 *
+	 * Enabling this option will return the error in full to the client
+	 * so that it might act accordingly.
+	 *
+	 * When enabled, this may expose more information than you might like
+	 * about your sytem.
+	 *
+	 * NOTE: If rrdtool errors because you're trying to submit data with an
+	 * illegal timestamp then we will tell the client so that it can make a
+	 * decision as to how to deal with the data it just gathered.
+	 *
+	 */
+	$rrdDetailedErrors = false;
+
+	/**
 	 * Automatically decide limits for graphs?
 	 *
 	 * If true, then $graphMin and $graphMax are multipliers on the min/max

--- a/web/submit.php
+++ b/web/submit.php
@@ -60,12 +60,7 @@
 				$errorNoPath = substr($result['stdout'],strrpos($result['stdout'],":")+2,-1);
 
 				// Check if the error is to do with illigal timestamp
-				if (startsWith($errorNoPath, "illegal attempt to update using time")) {
-					die(json_encode(array('error' => $errorNoPath)));
-				}
-
-				// If $rrdDetailedErrors is enabled, display the full error
-				if ($rrdDetailedErrors) {
+				if (startsWith($errorNoPath, "illegal attempt to update using time") || $rrdDetailedErrors) {
 					die(json_encode(array('error' => $errorNoPath)));
 				} else {
 					die(json_encode(array('error' => 'Internal Error')));

--- a/web/submit.php
+++ b/web/submit.php
@@ -56,7 +56,20 @@
 
 			$result = updateRRD($rrdDataFile, $dsname, $data['time'], $storeValue);
 			if (startsWith($result['stdout'], 'ERROR:')) {
-				die(json_encode(array('error' => 'Internal Error')));
+				//Strip path from the error along with new line
+				$errorNoPath = substr($result['stdout'],strrpos($result['stdout'],":")+2,-1);
+
+				// Check if the error is to do with illigal timestamp
+				if (startsWith($errorNoPath, "illegal attempt to update using time")) {
+					die(json_encode(array('error' => $errorNoPath)));
+				}
+
+				// If $rrdDetailedErrors is enabled, display the full error
+				if ($rrdDetailedErrors) {
+					die(json_encode(array('error' => $errorNoPath)));
+				} else {
+					die(json_encode(array('error' => 'Internal Error')));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I run two pollers (on the same network, but on two different machines) and with the recent changes to rrdtool error handling, i sometimes end up with a failure to submit on one of my probes and it will indefinitely try to resubmit the "invalid" data and the local cache would exponentially grow until the files are removed.

This patch is an attempt to work around that :)