### PR TITLE
Add probe names (so they show in access logs)

### DIFF
--- a/probe/config.php
+++ b/probe/config.php
@@ -3,6 +3,9 @@
 	/** This location. */
 	$location = 'Home';
 
+	/** This probe. */
+	$probe_name = 'Probe 1';
+
 	/** Submission Key. */
 	$submissionKey = 'SomePassword';
 

--- a/probe/probe.php
+++ b/probe/probe.php
@@ -159,7 +159,7 @@
 	}
 
 	function submitData($data, $url) {
-		global $location, $submissionKey;
+		global $location, $submissionKey, $probe_name;
 
 		$url = parse_url($url);
 		$thisUser = isset($url['user']) ? $url['user'] : $location;
@@ -175,6 +175,8 @@
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERPWD, $thisUser . ':' . $thisPass);
 		curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		curl_setopt($ch, CURLOPT_USERAGENT,'WeMo Probe: '.$probe_name);
+
 
 		$result = curl_exec($ch);
 		curl_close($ch);


### PR DESCRIPTION
```
2a03:b200:x:6231 - Home [30/Jun/2017:10:22:04 +0100] "POST /wemo/submit.php HTTP/1.1" 200 16 "-" "-"
```

vs

```
2a03:b200:x:6231 - Home [30/Jun/2017:10:22:19 +0100] "POST /wemo/submit.php HTTP/1.1" 200 16 "-" "WeMo Probe: Probe 1"
```
